### PR TITLE
Improve Java Properties detection

### DIFF
--- a/tests/fixtures/java.properties
+++ b/tests/fixtures/java.properties
@@ -3,7 +3,9 @@ baseDN=LDAP
 username=admin
 password=
 sonar.jdbc.password=
+api.key=
 
 # Noncompliant
 password=hardcoded01
 sonar.jdbc.password=hardcoded02
+api.key=dGhpc2lzYWhhcmRjb2RlZHN0cmluZzpECghardcoded03

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -76,7 +76,7 @@ def test_detection_by_key(src, keys):
         ("source.py", 5),
         ("plaintext.txt", 2),
         ("uri.yml", 2),
-        ("java.properties", 2),
+        ("java.properties", 3),
     ],
 )
 def test_detection_by_value(src, count):

--- a/whispers/__version__.py
+++ b/whispers/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 1, 4)
+VERSION = (1, 1, 5)
 
 __version__ = ".".join(map(str, VERSION))

--- a/whispers/plugins/jproperties.py
+++ b/whispers/plugins/jproperties.py
@@ -8,4 +8,5 @@ class Jproperties:
         props = Properties()
         props.load(filepath.read_text(), "utf-8")
         for key, value in props.properties.items():
+            key = key.replace(".", "_")
             yield key, value


### PR DESCRIPTION
Convert dots to underscores to adapt it to a typical variable name