### PR TITLE
Update lxml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def get_version():
     return import_module("whispers.__version__").__version__
 
 
-install_requires = ["luhn==0.2.0", "lxml==4.6.1", "pyyaml==5.3.1", "astroid==2.4.2", "jproperties==2.1.0", "python-levenshtein==0.12.0"]
+install_requires = ["luhn==0.2.0", "lxml==4.6.2", "pyyaml==5.3.1", "astroid==2.4.2", "jproperties==2.1.0", "python-levenshtein==0.12.0"]
 
 dev_requires = [
     "black>=19.10b0",

--- a/whispers/__version__.py
+++ b/whispers/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 3, 8)
+VERSION = (1, 3, 9)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
CVE-2020-27783
moderate severity
Vulnerable versions: < 4.6.2
Patched version: 4.6.2

A XSS vulnerability was discovered in python-lxml's clean module. The module's parser didn't properly imitate browsers, which caused different behaviors between the sanitizer and the user's page. A remote attacker could exploit this flaw to run arbitrary HTML/JS code.
